### PR TITLE
add [[ignore]] config table for specific file+line occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ mode = "ratchet"  # or "caps"
 include_deps = true
 ignore_units = ["test_crate"]
 
+# ignore specific occurrences by file + line (optional reason for reviewers)
+[[ignore]]
+file = "src/ffi.rs"
+line = 42
+reason = "ffi boundary, reviewed 2026-04-12"
+
+[[ignore]]
+file = "src/platform/windows.rs"
+line = 7
+
 [caps]
 default = 100
 [caps.workspace]

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,11 +242,17 @@ line = 7
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.ignore.len(), 2);
 
-        assert_eq!(config.ignore[0].file, std::path::PathBuf::from("src/ffi.rs"));
+        assert_eq!(
+            config.ignore[0].file,
+            std::path::PathBuf::from("src/ffi.rs")
+        );
         assert_eq!(config.ignore[0].line, 42);
         assert_eq!(config.ignore[0].reason.as_deref(), Some("ffi boundary"));
 
-        assert_eq!(config.ignore[1].file, std::path::PathBuf::from("src/platform.rs"));
+        assert_eq!(
+            config.ignore[1].file,
+            std::path::PathBuf::from("src/platform.rs")
+        );
         assert_eq!(config.ignore[1].line, 7);
         assert!(config.ignore[1].reason.is_none());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use crate::model::{Scope, Totals, Unit, UnitKind};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Budget enforcement mode.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +25,30 @@ pub struct Caps {
     pub deps: HashMap<String, u64>,
 }
 
+/// A single occurrence to ignore when counting unsafe code.
+///
+/// Matches a specific file and line number in the scan output. The `reason`
+/// field is optional documentation for reviewers.
+///
+/// # Example (unsafe-budget.toml)
+///
+/// ```toml
+/// [[ignore]]
+/// file = "src/ffi.rs"
+/// line = 42
+/// reason = "ffi boundary, reviewed 2026-04-12"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IgnoreEntry {
+    /// File path relative to the project root.
+    pub file: PathBuf,
+    /// Line number (1-indexed).
+    pub line: u32,
+    /// Optional human-readable reason for the ignore.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
 /// Warning configuration for near-budget usage.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Warnings {
@@ -43,6 +67,13 @@ pub struct Config {
     pub workspace_only: bool,
     #[serde(default)]
     pub ignore_units: Vec<String>,
+    /// Specific occurrences to exclude from counts.
+    ///
+    /// Each entry matches a file path and line number. Matched occurrences are
+    /// removed before budgets are checked, so they do not count toward any unit's
+    /// unsafe total.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore: Vec<IgnoreEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub caps: Option<Caps>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,6 +91,7 @@ impl Default for Config {
             include_deps: true,
             workspace_only: false,
             ignore_units: Vec::new(),
+            ignore: Vec::new(),
             caps: None,
             warnings: None,
         }
@@ -193,6 +225,36 @@ threshold = 0.8
         assert_eq!(caps.workspace.get("my_crate"), Some(&5));
         assert_eq!(caps.deps.get("libc"), Some(&100));
         assert_eq!(config.warnings.as_ref().unwrap().threshold, 0.8);
+    }
+
+    #[test]
+    fn test_config_ignore_parse() {
+        let toml = r#"
+[[ignore]]
+file = "src/ffi.rs"
+line = 42
+reason = "ffi boundary"
+
+[[ignore]]
+file = "src/platform.rs"
+line = 7
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.ignore.len(), 2);
+
+        assert_eq!(config.ignore[0].file, std::path::PathBuf::from("src/ffi.rs"));
+        assert_eq!(config.ignore[0].line, 42);
+        assert_eq!(config.ignore[0].reason.as_deref(), Some("ffi boundary"));
+
+        assert_eq!(config.ignore[1].file, std::path::PathBuf::from("src/platform.rs"));
+        assert_eq!(config.ignore[1].line, 7);
+        assert!(config.ignore[1].reason.is_none());
+    }
+
+    #[test]
+    fn test_config_ignore_empty_by_default() {
+        let config = Config::default();
+        assert!(config.ignore.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
+use std::collections::HashMap;
 use std::process::ExitCode;
 
 use unsafe_budget::analyzer::{detect_analyzer, get_analyzer, list_analyzers, Analyzer};
 use unsafe_budget::budget;
 use unsafe_budget::cli::{self, Command, ScanArgs};
-use unsafe_budget::config::{Baseline, BaselineUnit, Config};
+use unsafe_budget::config::{Baseline, BaselineUnit, Config, IgnoreEntry};
 use unsafe_budget::error::Result;
-use unsafe_budget::model::{ScanOpts, ScanResult};
+use unsafe_budget::model::{ScanOpts, ScanResult, Totals, UnitKind};
 use unsafe_budget::output::{self, Format};
 
 fn main() -> ExitCode {
@@ -36,6 +37,8 @@ fn cmd_scan(args: ScanArgs) -> Result<ExitCode> {
 
     let mut result = analyzer.run(&opts)?;
 
+    result = apply_ignore_filter(result, &config.ignore);
+
     // Filter details if not requested
     if !args.details {
         result.details.clear();
@@ -51,6 +54,7 @@ fn cmd_check(args: ScanArgs) -> Result<ExitCode> {
     let analyzer = get_analyzer_for_args(&args, &opts)?;
 
     let result = analyzer.run(&opts)?;
+    let result = apply_ignore_filter(result, &config.ignore);
 
     // Load baseline for ratchet mode
     let baseline = match config.mode {
@@ -78,6 +82,7 @@ fn cmd_update(args: ScanArgs) -> Result<ExitCode> {
     let analyzer = get_analyzer_for_args(&args, &opts)?;
 
     let result = analyzer.run(&opts)?;
+    let result = apply_ignore_filter(result, &config.ignore);
 
     let baseline = build_baseline(&result, analyzer.as_ref());
     let dir = get_project_dir(&args);
@@ -149,6 +154,53 @@ fn build_scan_opts(args: &ScanArgs, config: &Config) -> ScanOpts {
         targets: args.targets.clone(),
         manifest_path: args.manifest_path.clone(),
     }
+}
+
+/// Remove occurrences that match an `[[ignore]]` config entry and recompute unit
+/// counts and totals. A match requires both the file path and line number to be
+/// equal; the `reason` field is documentation only.
+///
+/// If `ignores` is empty this is a no-op.
+fn apply_ignore_filter(mut result: ScanResult, ignores: &[IgnoreEntry]) -> ScanResult {
+    if ignores.is_empty() {
+        return result;
+    }
+
+    result.details.retain(|occ| {
+        !ignores
+            .iter()
+            .any(|rule| rule.file == occ.file && rule.line == occ.line)
+    });
+
+    // Recompute per-unit counts from the filtered details.
+    let mut counts: HashMap<&str, u64> = HashMap::new();
+    for occ in &result.details {
+        *counts.entry(occ.unit.as_str()).or_default() += 1;
+    }
+    for unit in &mut result.units {
+        unit.unsafe_count = counts.get(unit.name.as_str()).copied().unwrap_or(0);
+    }
+
+    // Recompute totals.
+    let workspace_unsafe: u64 = result
+        .units
+        .iter()
+        .filter(|u| u.kind == UnitKind::Workspace)
+        .map(|u| u.unsafe_count)
+        .sum();
+    let deps_unsafe: u64 = result
+        .units
+        .iter()
+        .filter(|u| u.kind == UnitKind::Dep)
+        .map(|u| u.unsafe_count)
+        .sum();
+    result.totals = Totals {
+        workspace_unsafe,
+        deps_unsafe,
+        overall_unsafe: workspace_unsafe + deps_unsafe,
+    };
+
+    result
 }
 
 fn build_baseline(result: &ScanResult, analyzer: &dyn Analyzer) -> Baseline {


### PR DESCRIPTION
closes #3 (config-based approach)

## What

Adds `IgnoreEntry { file, line, reason }` and an `[[ignore]]` TOML array-of-tables to the config. Each entry names a file path (relative to the project root) and a line number. Matched occurrences are filtered out before budgets are checked, so they do not count toward any unit's unsafe total. Unit counts and totals are recomputed after filtering.

```toml
# unsafe-budget.toml
[[ignore]]
file = "src/ffi.rs"
line = 42
reason = "ffi boundary, reviewed 2026-04-12"

[[ignore]]
file = "src/platform/windows.rs"
line = 7
```

The filter is applied in all three commands (`scan`, `check`, `update`) so the baseline reflects the post-ignore counts from the start.

## What's deferred

The inline-comment approach (`// unsafe-budget: ignore`) from the issue is left for a follow-up. It would require the analyzer to read source files at scan time to correlate comments with diagnostics, which is a larger change and may need its own design pass.

## Tests

Two new unit tests in `config.rs` cover TOML parsing of `[[ignore]]` entries (with and without `reason`). All 113 existing tests continue to pass.